### PR TITLE
[FIX] Point 엔티티명 변경

### DIFF
--- a/src/main/java/depth/mvp/ns/domain/board/service/BoardService.java
+++ b/src/main/java/depth/mvp/ns/domain/board/service/BoardService.java
@@ -6,12 +6,11 @@ import depth.mvp.ns.domain.board.dto.request.PublishReq;
 import depth.mvp.ns.domain.board.dto.request.SaveDraftReq;
 import depth.mvp.ns.domain.board.dto.request.UpdateReq;
 import depth.mvp.ns.domain.board.dto.response.BoardLikeRes;
-import depth.mvp.ns.domain.board.dto.response.ThemeLikeRes;
 import depth.mvp.ns.domain.board_like.domain.BoardLike;
 import depth.mvp.ns.domain.board_like.domain.repository.BoardLikeRepository;
 import depth.mvp.ns.domain.common.Status;
-import depth.mvp.ns.domain.point.domain.Point;
-import depth.mvp.ns.domain.point.domain.repository.PointRepository;
+import depth.mvp.ns.domain.user_point.domain.UserPoint;
+import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.board.dto.response.BoardDetailRes;
 import depth.mvp.ns.domain.theme.domain.Theme;
 import depth.mvp.ns.domain.theme.domain.repository.ThemeRepository;
@@ -24,13 +23,11 @@ import depth.mvp.ns.global.payload.ApiResponse;
 import depth.mvp.ns.global.payload.DefaultAssert;
 import depth.mvp.ns.global.payload.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cglib.core.Local;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Service
@@ -41,7 +38,7 @@ public class BoardService {
     private final BoardLikeRepository boardLikeRepository;
     private final UserRepository userRepository;
     private final ThemeRepository themeRepository;
-    private final PointRepository pointRepository;
+    private final UserPointRepository userPointRepository;
     private final ThemeLikeRepository themeLikeRepository;
 
     @Transactional
@@ -255,20 +252,20 @@ public class BoardService {
     }
 
     private void savePointHistory(User user, int score) {
-        Point point = Point.builder()
+        UserPoint userPoint = UserPoint.builder()
                 .user(user)
                 .score(score)
                 .build();
-        pointRepository.save(point);
+        userPointRepository.save(userPoint);
     }
 
     private void deletePointHistory(User user, LocalDate date, int score) {
         // 부여된 날짜 및 score로 point 찾기
-        Optional<Point> pointOptional = pointRepository.findByUserAndCreatedDateAndScore(user, date, score);
+        Optional<UserPoint> pointOptional = userPointRepository.findByUserAndCreatedDateAndScore(user, date, score);
         DefaultAssert.isTrue(pointOptional.isPresent(), "포인트 내역이 존재하지 않습니다.");
-        Point point = pointOptional.get();
+        UserPoint userPoint = pointOptional.get();
 
-        pointRepository.delete(point);
+        userPointRepository.delete(userPoint);
     }
 
     // 게시글 조회

--- a/src/main/java/depth/mvp/ns/domain/report/service/ReportService.java
+++ b/src/main/java/depth/mvp/ns/domain/report/service/ReportService.java
@@ -3,8 +3,8 @@ package depth.mvp.ns.domain.report.service;
 import com.querydsl.core.Tuple;
 import depth.mvp.ns.domain.board.domain.Board;
 import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
-import depth.mvp.ns.domain.point.domain.Point;
-import depth.mvp.ns.domain.point.domain.repository.PointRepository;
+import depth.mvp.ns.domain.user_point.domain.UserPoint;
+import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.report.domain.Report;
 import depth.mvp.ns.domain.report.domain.WordCount;
 import depth.mvp.ns.domain.report.domain.repository.ReportRepository;
@@ -26,7 +26,6 @@ import lombok.RequiredArgsConstructor;
 import org.openkoreantext.processor.KoreanTokenJava;
 import org.openkoreantext.processor.OpenKoreanTextProcessorJava;
 import org.openkoreantext.processor.tokenizer.KoreanTokenizer;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -57,7 +56,7 @@ public class ReportService {
     private final CloudImageGenerator cloudImageGenerator;
     private final S3Uploader s3Uploader;
     private final UserRepository userRepository;
-    private final PointRepository pointRepository;
+    private final UserPointRepository userPointRepository;
 
 
     public ResponseEntity<?> findReport(CustomUserDetails customUserDetails, LocalDate parsedDate) {
@@ -273,12 +272,12 @@ public class ReportService {
 
                     user.addPoint(5);
 
-                    Point point = Point.builder()
+                    UserPoint userPoint = UserPoint.builder()
                             .user(user)
                             .score(5)
                             .build();
 
-                    pointRepository.save(point);
+                    userPointRepository.save(userPoint);
                     return board;
                 }
         ).collect(Collectors.toList());

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -3,8 +3,8 @@ package depth.mvp.ns.domain.theme.service;
 import depth.mvp.ns.domain.board.domain.Board;
 import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
 import depth.mvp.ns.domain.common.Status;
-import depth.mvp.ns.domain.point.domain.Point;
-import depth.mvp.ns.domain.point.domain.repository.PointRepository;
+import depth.mvp.ns.domain.user_point.domain.UserPoint;
+import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.theme.domain.Theme;
 import depth.mvp.ns.domain.theme.domain.repository.ThemeRepository;
 import depth.mvp.ns.domain.theme.dto.response.ThemeDetailRes;
@@ -44,7 +44,7 @@ public class ThemeService {
     private final ThemeLikeRepository themeLikeRepository;
     private final UserRepository userRepository;
     private final BoardRepository boardRepository;
-    private final PointRepository pointRepository;
+    private final UserPointRepository userPointRepository;
 
     // 오늘의 주제 조회
     public ResponseEntity<?> getTodayTheme(@CurrentUser CustomUserDetails customUserDetails) {
@@ -261,20 +261,20 @@ public class ThemeService {
     }
 
     private void savePointHistory(User user, int score) {
-        Point point = Point.builder()
+        UserPoint userPoint = UserPoint.builder()
                 .user(user)
                 .score(score)
                 .build();
-        pointRepository.save(point);
+        userPointRepository.save(userPoint);
     }
 
     private void deletePointHistory(User user, LocalDate date, int score) {
         // 부여된 날짜 및 score로 point 찾기
-        Optional<Point> pointOptional = pointRepository.findByUserAndCreatedDateAndScore(user, date, score);
+        Optional<UserPoint> pointOptional = userPointRepository.findByUserAndCreatedDateAndScore(user, date, score);
         DefaultAssert.isTrue(pointOptional.isPresent(), "포인트 내역이 존재하지 않습니다.");
-        Point point = pointOptional.get();
+        UserPoint userPoint = pointOptional.get();
 
-        pointRepository.delete(point);
+        userPointRepository.delete(userPoint);
     }
 
 }

--- a/src/main/java/depth/mvp/ns/domain/user/domain/repository/UserQueryDslRepositoryImpl.java
+++ b/src/main/java/depth/mvp/ns/domain/user/domain/repository/UserQueryDslRepositoryImpl.java
@@ -2,7 +2,6 @@ package depth.mvp.ns.domain.user.domain.repository;
 
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import depth.mvp.ns.domain.point.domain.QPoint;
 import depth.mvp.ns.domain.user.domain.RankingType;
 import depth.mvp.ns.domain.user.dto.response.*;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +10,11 @@ import org.springframework.stereotype.Repository;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
-import static depth.mvp.ns.domain.point.domain.QPoint.point;
+import static depth.mvp.ns.domain.user_point.domain.QUserPoint.userPoint;
 import static depth.mvp.ns.domain.user.domain.QUser.user;
 
 @RequiredArgsConstructor
@@ -80,15 +78,15 @@ public class UserQueryDslRepositoryImpl implements UserQueryDslRepository {
                         user.id,
                         user.nickname,
                         user.imageUrl,
-                        point.score.sum(),
+                        userPoint.score.sum(),
                         id != null ? user.id.eq(id) : Expressions.asBoolean(false)
                 ))
-                .from(point)
+                .from(userPoint)
                 .leftJoin(user)
-                .on(point.user.id.eq(user.id))
-                .where(point.createdDate.between(startDate, endDate))
+                .on(userPoint.user.id.eq(user.id))
+                .where(userPoint.createdDate.between(startDate, endDate))
                 .groupBy(user.id, user.nickname, user.imageUrl)
-                .orderBy(point.score.sum().desc())
+                .orderBy(userPoint.score.sum().desc())
                 .limit(3)
                 .fetch();
 
@@ -97,15 +95,15 @@ public class UserQueryDslRepositoryImpl implements UserQueryDslRepository {
                         Expressions.constant(0L), // 랭킹
                         user.id,
                         user.nickname,
-                        point.score.sum(),
+                        userPoint.score.sum(),
                         id != null ? user.id.eq(id) : Expressions.asBoolean(false)
                 ))
-                .from(point)
+                .from(userPoint)
                 .leftJoin(user)
-                .on(point.user.id.eq(user.id))
-                .where(point.createdDate.between(startDate, endDate))
+                .on(userPoint.user.id.eq(user.id))
+                .where(userPoint.createdDate.between(startDate, endDate))
                 .groupBy(user.id, user.nickname)
-                .orderBy(point.score.sum().desc())
+                .orderBy(userPoint.score.sum().desc())
                 .limit(10)
                 .fetch();
 
@@ -132,7 +130,7 @@ public class UserQueryDslRepositoryImpl implements UserQueryDslRepository {
                             Expressions.constant(0L),
                             user.id,
                             user.nickname,
-                            point.score.sum(),
+                            userPoint.score.sum(),
                             user.id.eq(id)
                     ))
                     .from(user)

--- a/src/main/java/depth/mvp/ns/domain/user_point/domain/UserPoint.java
+++ b/src/main/java/depth/mvp/ns/domain/user_point/domain/UserPoint.java
@@ -1,4 +1,4 @@
-package depth.mvp.ns.domain.point.domain;
+package depth.mvp.ns.domain.user_point.domain;
 
 import depth.mvp.ns.domain.common.BaseEntity;
 import depth.mvp.ns.domain.user.domain.User;
@@ -11,11 +11,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Point extends BaseEntity {
+public class UserPoint extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "point_id")
+    @Column(name = "user_point_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -25,7 +25,7 @@ public class Point extends BaseEntity {
     private int score;
 
     @Builder
-    public Point(User user, int score) {
+    public UserPoint(User user, int score) {
         this.user = user;
         this.score = score;
     }

--- a/src/main/java/depth/mvp/ns/domain/user_point/domain/repository/UserPointRepository.java
+++ b/src/main/java/depth/mvp/ns/domain/user_point/domain/repository/UserPointRepository.java
@@ -1,6 +1,6 @@
-package depth.mvp.ns.domain.point.domain.repository;
+package depth.mvp.ns.domain.user_point.domain.repository;
 
-import depth.mvp.ns.domain.point.domain.Point;
+import depth.mvp.ns.domain.user_point.domain.UserPoint;
 import depth.mvp.ns.domain.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,10 +11,10 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 @Repository
-public interface PointRepository extends JpaRepository<Point, Long> {
+public interface UserPointRepository extends JpaRepository<UserPoint, Long> {
 
-    @Query("SELECT p FROM Point p WHERE p.user = :user AND DATE(p.createdDate) = :date AND p.score = :score")
-    Optional<Point> findByUserAndCreatedDateAndScore(
+    @Query("SELECT p FROM UserPoint p WHERE p.user = :user AND DATE(p.createdDate) = :date AND p.score = :score")
+    Optional<UserPoint> findByUserAndCreatedDateAndScore(
             @Param("user") User user,
             @Param("date") LocalDate date,
             @Param("score") int score


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- user 테이블의 point 컬럼과 Point 엔티티명이 겹쳐 오류가 발생하는 것을 확인하여 Point 엔티티명을 UserPoint로 수정함


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
- userPoint로 변경함으로써 `/api/v1/user/ranking` API repository의 내부 코드를 변경함
[변경사항] `UserQueryDslRepositoryImpl` 중
```
1. import static depth.mvp.ns.domain.user_point.domain.QUserPoint.userPoint;
```
```
2. getNRankingDesc 에서

List<UserRankingRes.Top3UserRes> top3Users = queryFactory
                .select(new QUserRankingRes_Top3UserRes(
                        user.id,
                        user.nickname,
                        user.imageUrl,
                        userPoint.score.sum(),
                        id != null ? user.id.eq(id) : Expressions.asBoolean(false)
                ))
                .from(userPoint)
                .leftJoin(user)
                .on(userPoint.user.id.eq(user.id))
                .where(userPoint.createdDate.between(startDate, endDate))
                .groupBy(user.id, user.nickname, user.imageUrl)
                .orderBy(userPoint.score.sum().desc())
                .limit(3)
                .fetch();
```
올바르게 변경했는지 확인부탁드립니다~

## ✅Check
- [ ] 각 기능에 대한 테스트
- [ ] label
- [ ] API 명세서 작성


## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
