### PR TITLE
[FEAT] 주제 조회 + 정렬 api에 페이지 관련 값 추가

### DIFF
--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -26,10 +26,10 @@ public class ThemeController {
 
     @GetMapping("/list")
     public ResponseEntity<?> getThemeList(
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "3") int size,
             @RequestParam(defaultValue = "date") String sortBy) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
         return themeService.getThemeList(pageable, sortBy);
     }
 

--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -36,9 +36,9 @@ public class ThemeController {
     @GetMapping("/search")
     public ResponseEntity<?> searchTheme(
             @RequestParam String keyword,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "3") int size){
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
         return themeService.searchTheme(keyword, pageable);
     }
 
@@ -47,10 +47,10 @@ public class ThemeController {
     public ResponseEntity<?> getThemeDetail(
             @CurrentUser CustomUserDetails customUserDetails,
             @PathVariable Long themeId,
-            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "2") int size,
             @RequestParam(defaultValue = "date") String sortBy) {
-        Pageable pageable = PageRequest.of(page, size);
+        Pageable pageable = PageRequest.of(page - 1, size);
         return themeService.getThemeDetail(themeId, sortBy, pageable, customUserDetails);
     }
 }

--- a/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeDetailRes.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeDetailRes.java
@@ -1,5 +1,6 @@
 package depth.mvp.ns.domain.theme.dto.response;
 
+import depth.mvp.ns.global.payload.PageInfo;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -10,6 +11,7 @@ import java.util.List;
 
 @Getter
 public class ThemeDetailRes {
+    private PageInfo pageInfo; // 페이지 정보
     private  Long userId; // 사용자ID
     private  boolean likedTheme; // 주제 좋아요 여부
     private String content; // 주제 내용
@@ -18,7 +20,8 @@ public class ThemeDetailRes {
     private List<BoardRes> boards; // 게시글 목록
 
     @Builder
-    public ThemeDetailRes(Long userId, boolean likedTheme, String content, LocalDate date, int likeCount, List<BoardRes> boards){
+    public ThemeDetailRes(PageInfo pageInfo, Long userId, boolean likedTheme, String content, LocalDate date, int likeCount, List<BoardRes> boards){
+        this.pageInfo = pageInfo;
         this.userId = userId;
         this.likedTheme = likedTheme;
         this.content = content;

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -3,6 +3,7 @@ package depth.mvp.ns.domain.theme.service;
 import depth.mvp.ns.domain.board.domain.Board;
 import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
 import depth.mvp.ns.domain.common.Status;
+import depth.mvp.ns.domain.user.dto.response.PageRes;
 import depth.mvp.ns.domain.user_point.domain.UserPoint;
 import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.theme.domain.Theme;
@@ -22,6 +23,7 @@ import depth.mvp.ns.global.error.InvalidParameterException;
 import depth.mvp.ns.global.payload.ApiResponse;
 import depth.mvp.ns.global.payload.DefaultAssert;
 import depth.mvp.ns.global.payload.ErrorCode;
+import depth.mvp.ns.global.payload.PageInfo;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -252,9 +254,21 @@ public class ThemeService {
                             .build();
                 }).collect(Collectors.toList());
 
+        PageInfo pageInfo = PageInfo.builder()
+                .pageNumber(themePage.getNumber())
+                .pageSize(themePage.getSize())
+                .totalElements(themePage.getTotalElements())
+                .totalPages(themePage.getTotalPages())
+                .build();
+
+        PageRes<ThemeListRes> pageRes = PageRes.<ThemeListRes>builder()
+                .pageInfo(pageInfo)
+                .resList(themeListRes)
+                .build();
+
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(themeListRes)
+                .information(pageRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -191,7 +191,16 @@ public class ThemeService {
             likedTheme = themeLikeRepository.existsByThemeAndUserAndStatus(theme, user, Status.ACTIVE);
         }
 
+        // 페이지 정보 생성
+        PageInfo pageInfo = PageInfo.builder()
+                .pageNumber(boardPage.getNumber() + 1) //페이지 번호 1부터 시작
+                .pageSize(boardPage.getSize())
+                .totalElements(boardPage.getTotalElements())
+                .totalPages(boardPage.getTotalPages())
+                .build();
+
         ThemeDetailRes themeDetailRes = ThemeDetailRes.builder()
+                .pageInfo(pageInfo)
                 .userId(userId)
                 .likedTheme(likedTheme)
                 .content(theme.getContent())

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -255,7 +255,7 @@ public class ThemeService {
                 }).collect(Collectors.toList());
 
         PageInfo pageInfo = PageInfo.builder()
-                .pageNumber(themePage.getNumber())
+                .pageNumber(themePage.getNumber() + 1) //페이지 번호 1부터 시작
                 .pageSize(themePage.getSize())
                 .totalElements(themePage.getTotalElements())
                 .totalPages(themePage.getTotalPages())

--- a/src/main/java/depth/mvp/ns/global/config/security/SecurityConfig.java
+++ b/src/main/java/depth/mvp/ns/global/config/security/SecurityConfig.java
@@ -57,6 +57,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         // 특정 GET 요청만 인증 없이 접근 가능
                         .requestMatchers(HttpMethod.GET, "/api/v1/board/{boardId}").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/theme/**").permitAll()
                         .requestMatchers("/api/v1/board/**").authenticated()
                         .requestMatchers(
                                 antMatcher("/"),
@@ -70,7 +71,6 @@ public class SecurityConfig {
                                 antMatcher("/v3/api-docs/**"),
                                 antMatcher("/auth/**"),
                                 antMatcher("/api/v1/report/**"),
-                                antMatcher("/api/v1/theme/today"),
                                 antMatcher("/api/v1/report/generate"),
                                 antMatcher("/api/v1/user/profile/**"),
                                 antMatcher("/api/v1/user/nickname"),


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 주제 목록 조회&정렬, 주제 검색&정렬, 주제 상세 조회&정렬api에 페이지 관련 값 추가하는 기능을 구현하였습니다.
- GET 요청(/api/v1/theme/**)은 인증 없이 접근 가능하도록 설정했습니다.
-수정된 부분 테스트 완료하였습니다!

## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-


## ✅Check
- [ ] 각 기능에 대한 테스트
- [ ] label
- [ ] API 명세서 작성


## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
