### PR TITLE
[FEAT] 주제 목록 조회, 주제 상세 조회 응답에  좋아요 여부 기능 구현

### DIFF
--- a/src/main/java/depth/mvp/ns/domain/board_like/domain/repository/BoardLikeRepository.java
+++ b/src/main/java/depth/mvp/ns/domain/board_like/domain/repository/BoardLikeRepository.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
@@ -44,4 +45,6 @@ public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
             Pageable pageable
     );
 
+    @Query("SELECT b.board.id FROM BoardLike b WHERE b.user.id = :userId AND b.status = :status")
+    Set<Long> findLikedBoardIdsByUserId(@Param("userId") Long userId, @Param("status") Status status);
 }

--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -26,20 +26,22 @@ public class ThemeController {
 
     @GetMapping("/list")
     public ResponseEntity<?> getThemeList(
+            @CurrentUser CustomUserDetails customUserDetails,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "3") int size,
             @RequestParam(defaultValue = "date") String sortBy) {
         Pageable pageable = PageRequest.of(page - 1, size);
-        return themeService.getThemeList(pageable, sortBy);
+        return themeService.getThemeList(customUserDetails, pageable, sortBy);
     }
 
     @GetMapping("/search")
     public ResponseEntity<?> searchTheme(
+            @CurrentUser CustomUserDetails customUserDetails,
             @RequestParam String keyword,
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "3") int size){
         Pageable pageable = PageRequest.of(page - 1, size);
-        return themeService.searchTheme(keyword, pageable);
+        return themeService.searchTheme(customUserDetails, keyword, pageable);
     }
 
 

--- a/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeDetailRes.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeDetailRes.java
@@ -38,15 +38,18 @@ public class ThemeDetailRes {
         private String nickname; // 작성자 닉네임
         private String date; // 게시글 작성일
         private int likeCount; // 게시글 좋아요 수
+        private boolean likedBoard; // 게시글 좋아요 여부
 
         @Builder
-        public BoardRes(Long boardId, String title, String content, String nickname, LocalDateTime date, int likeCount){
+        public BoardRes(Long boardId, String title, String content,
+                        String nickname, LocalDateTime date, int likeCount, boolean likedBoard){
             this.boardId = boardId;
             this.title = title;
             this.content = content;
             this.nickname = nickname;
             this.date = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
             this.likeCount =likeCount;
+            this.likedBoard = likedBoard;
         }
     }
 }

--- a/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeListRes.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeListRes.java
@@ -1,26 +1,45 @@
 package depth.mvp.ns.domain.theme.dto.response;
 
+import depth.mvp.ns.global.payload.PageInfo;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Getter
 public class ThemeListRes {
-    private Long themeId; // 주제ID
-    private String content; // 주제 내용
-    private String date; // 주제 발행일
-    private int likeCount; // 주제 좋아요수
-    private int boardCount; // 게시글 수
+    private Long userId; // 회원ID
+    private PageInfo pageInfo; // 페이지 정보
+    private List<ThemeList> themeList; // 주제 목록
 
     @Builder
-    ThemeListRes(Long themeId, String content, LocalDate date, int likeCount, int boardCount){
-        this.themeId = themeId;
-        this.content = content;
-        this.date = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
-        this.likeCount = likeCount;
-        this.boardCount = boardCount;
+    public ThemeListRes(Long userId, PageInfo pageInfo, List<ThemeList> themeList){
+        this.userId = userId;
+        this.pageInfo = pageInfo;
+        this.themeList = themeList;
     }
+
+    @Getter
+    public static class ThemeList {
+        private Long themeId; // 주제ID
+        private String content; // 주제 내용
+        private String date; // 주제 발행일
+        private int likeCount; // 주제 좋아요수
+        private int boardCount; // 게시글 수
+        private boolean likedTheme; // 주제 좋아요 여부
+
+        @Builder
+        public ThemeList(Long themeId, String content, LocalDate date, int likeCount, int boardCount, boolean likedTheme) {
+            this.themeId = themeId;
+            this.content = content;
+            this.date = date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+            this.likeCount = likeCount;
+            this.boardCount = boardCount;
+            this.likedTheme = likedTheme;
+        }
+    }
+
 }
 

--- a/src/main/java/depth/mvp/ns/domain/theme/dto/response/TodayThemeRes.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/dto/response/TodayThemeRes.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 
 @Getter
 public class TodayThemeRes {
+    private Long themeId; // 주제ID
     private String content; // 오늘의 주제
     private Long userId; // 사용자ID
     private boolean likedTheme; // 주제 좋아요 여부
 
     @Builder
-    public TodayThemeRes(String content, Long userId, boolean likedTheme){
+    public TodayThemeRes(Long themeId,String content, Long userId, boolean likedTheme){
+        this.themeId = themeId;
         this.content = content;
         this.userId = userId;
         this.likedTheme = likedTheme;

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -4,7 +4,6 @@ import depth.mvp.ns.domain.board.domain.Board;
 import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
 import depth.mvp.ns.domain.board_like.domain.repository.BoardLikeRepository;
 import depth.mvp.ns.domain.common.Status;
-import depth.mvp.ns.domain.user.dto.response.PageRes;
 import depth.mvp.ns.domain.user_point.domain.UserPoint;
 import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.theme.domain.Theme;
@@ -36,9 +35,8 @@ import org.springframework.validation.Errors;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -66,6 +66,7 @@ public class ThemeService {
         }
 
         TodayThemeRes todayThemeRes = TodayThemeRes.builder()
+                .themeId(theme.getId())
                 .content(theme.getContent())
                 .userId(userId)
                 .likedTheme(likedTheme)


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 주제 목록 조회+정렬, 주제 검색+정렬 응답에도 주제 좋아요 여부와 회원ID를 추가하였습니다.
- 주제 상세 조회 응답에는 각 게시 글에 글 좋아요 여부를 추가하였습니다.
    +주제 상세 조회 응답 방식을 조금 변경하였습니다!
- 오늘의 주제 조회 응답에 주제ID도 추가하였습니다.


## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-


## ✅Check
- [ ] 각 기능에 대한 테스트
- [ ] label
- [ ] API 명세서 작성


## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
