### PR TITLE
[FEAT] 지난 주제 조회 기능 구현

### DIFF
--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -19,7 +19,7 @@ public class ThemeController {
         return themeService.getTodayTheme(customUserDetails);
     }
 
-    @GetMapping("/past/{themeId}")
+    @GetMapping("/{themeId}/past")
     public ResponseEntity<?> getPastTheme(@CurrentUser CustomUserDetails customUserDetails, @PathVariable Long themeId){
         return themeService.getPastTheme(customUserDetails, themeId);
     }

--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -19,6 +19,11 @@ public class ThemeController {
         return themeService.getTodayTheme(customUserDetails);
     }
 
+    @GetMapping("past/{themeId}")
+    public ResponseEntity<?> getPastTheme(@CurrentUser CustomUserDetails customUserDetails, @PathVariable Long themeId){
+        return themeService.getPastTheme(customUserDetails, themeId);
+    }
+
     @PostMapping("/{themeId}/like")
     public ResponseEntity<?> hitTheThemeLikeButton(@CurrentUser CustomUserDetails customUserDetails, @PathVariable Long themeId) {
         return themeService.hitLikeButton(customUserDetails, themeId);

--- a/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/controller/ThemeController.java
@@ -19,7 +19,7 @@ public class ThemeController {
         return themeService.getTodayTheme(customUserDetails);
     }
 
-    @GetMapping("past/{themeId}")
+    @GetMapping("/past/{themeId}")
     public ResponseEntity<?> getPastTheme(@CurrentUser CustomUserDetails customUserDetails, @PathVariable Long themeId){
         return themeService.getPastTheme(customUserDetails, themeId);
     }

--- a/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeRes.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/dto/response/ThemeRes.java
@@ -4,14 +4,14 @@ import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-public class TodayThemeRes {
+public class ThemeRes {
     private Long themeId; // 주제ID
     private String content; // 오늘의 주제
     private Long userId; // 사용자ID
     private boolean likedTheme; // 주제 좋아요 여부
 
     @Builder
-    public TodayThemeRes(Long themeId,String content, Long userId, boolean likedTheme){
+    public ThemeRes(Long themeId,String content, Long userId, boolean likedTheme){
         this.themeId = themeId;
         this.content = content;
         this.userId = userId;

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -80,6 +80,36 @@ public class ThemeService {
         return ResponseEntity.ok(apiResponse);
     }
 
+    // 지난 주제 조회
+    public ResponseEntity<?> getPastTheme(@CurrentUser CustomUserDetails customUserDetails, Long themeId) {
+        Theme theme = validateTheme(themeId);
+
+        // 회원인지 여부에 따른 처리
+        Long userId = null;
+        boolean likedTheme = false; // 주제 좋아요 여부
+
+        // 주제에 대한 좋아요 여부 확인하고 응답값 넘겨주기
+        if(customUserDetails != null){
+            User user = validateUser(customUserDetails.getId());
+            userId = user.getId();
+            likedTheme = themeLikeRepository.existsByThemeAndUserAndStatus(theme, user, Status.ACTIVE);
+        }
+
+        TodayThemeRes pastThemeRes = TodayThemeRes.builder()
+                .themeId(theme.getId())
+                .content(theme.getContent())
+                .userId(userId)
+                .likedTheme(likedTheme)
+                .build();
+
+        ApiResponse apiResponse = ApiResponse.builder()
+                .check(true)
+                .information(pastThemeRes)
+                .build();
+
+        return ResponseEntity.ok(apiResponse);
+    }
+
     // 주제 좋아요
     @Transactional
     public ResponseEntity<?> hitLikeButton(CustomUserDetails customUserDetails, Long themeId) {

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -4,6 +4,7 @@ import depth.mvp.ns.domain.board.domain.Board;
 import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
 import depth.mvp.ns.domain.board_like.domain.repository.BoardLikeRepository;
 import depth.mvp.ns.domain.common.Status;
+import depth.mvp.ns.domain.theme.dto.response.ThemeRes;
 import depth.mvp.ns.domain.user_point.domain.UserPoint;
 import depth.mvp.ns.domain.user_point.domain.repository.UserPointRepository;
 import depth.mvp.ns.domain.theme.domain.Theme;
@@ -11,7 +12,6 @@ import depth.mvp.ns.domain.theme.domain.repository.ThemeRepository;
 import depth.mvp.ns.domain.theme.dto.response.ThemeDetailRes;
 import depth.mvp.ns.domain.theme.dto.response.ThemeLikeRes;
 import depth.mvp.ns.domain.theme.dto.response.ThemeListRes;
-import depth.mvp.ns.domain.theme.dto.response.TodayThemeRes;
 import depth.mvp.ns.domain.theme_like.domain.ThemeLike;
 import depth.mvp.ns.domain.theme_like.domain.repository.ThemeLikeRepository;
 import depth.mvp.ns.domain.user.domain.User;
@@ -54,48 +54,28 @@ public class ThemeService {
         Theme theme = themeRepository.findByDate(LocalDate.now())
                 .orElseThrow(() -> new DefaultException(ErrorCode.CONTENTS_NOT_FOUND, "주제를 찾을 수 없습니다."));
 
-        // 회원인지 여부에 따른 처리
-        Long userId = null;
-        boolean likedTheme = false; // 주제 좋아요 여부
-
-        // 주제에 대한 좋아요 여부 확인하고 응답값 넘겨주기
-        if(customUserDetails != null){
-            User user = validateUser(customUserDetails.getId());
-            userId = user.getId();
-            likedTheme = themeLikeRepository.existsByThemeAndUserAndStatus(theme, user, Status.ACTIVE);
-        }
-
-        TodayThemeRes todayThemeRes = TodayThemeRes.builder()
-                .themeId(theme.getId())
-                .content(theme.getContent())
-                .userId(userId)
-                .likedTheme(likedTheme)
-                .build();
-
-        ApiResponse apiResponse = ApiResponse.builder()
-                .check(true)
-                .information(todayThemeRes)
-                .build();
-
-        return ResponseEntity.ok(apiResponse);
+        return getThemeResponse(theme, customUserDetails);
     }
 
     // 지난 주제 조회
     public ResponseEntity<?> getPastTheme(@CurrentUser CustomUserDetails customUserDetails, Long themeId) {
         Theme theme = validateTheme(themeId);
 
-        // 회원인지 여부에 따른 처리
+        return getThemeResponse(theme, customUserDetails);
+    }
+
+    // 주제 정보 가져와서 응답 생성하는 메서드
+    private ResponseEntity<?> getThemeResponse(Theme theme, CustomUserDetails customUserDetails) {
         Long userId = null;
         boolean likedTheme = false; // 주제 좋아요 여부
 
-        // 주제에 대한 좋아요 여부 확인하고 응답값 넘겨주기
-        if(customUserDetails != null){
+        if (customUserDetails != null) {
             User user = validateUser(customUserDetails.getId());
             userId = user.getId();
             likedTheme = themeLikeRepository.existsByThemeAndUserAndStatus(theme, user, Status.ACTIVE);
         }
 
-        TodayThemeRes pastThemeRes = TodayThemeRes.builder()
+        ThemeRes themeRes = ThemeRes.builder()
                 .themeId(theme.getId())
                 .content(theme.getContent())
                 .userId(userId)
@@ -104,7 +84,7 @@ public class ThemeService {
 
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information(pastThemeRes)
+                .information(themeRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 지난 주제 조회 기능을 구현했습니다.
- 오늘의 주제 조회랑 코드가 거의 일치하여 공통 메서드를 생성했습니다. + 응답 DTO클래스 이름도 변경하였습니다!

## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-


## ✅Check
- [ ] 각 기능에 대한 테스트
- [ ] label
- [ ] API 명세서 작성


## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
