### PR TITLE
[FEAT] 임시 저장 api응답에 boardId값 추가, 주제 상세 조회 시 발행된 게시 글 조회 조건 추가

### DIFF
--- a/src/main/java/depth/mvp/ns/domain/board/domain/repository/BoardRepository.java
+++ b/src/main/java/depth/mvp/ns/domain/board/domain/repository/BoardRepository.java
@@ -18,12 +18,12 @@ public interface BoardRepository extends JpaRepository<Board, Long>, BoardQueryD
     @Query("SELECT COUNT(l) FROM BoardLike l WHERE l.board.id = :boardId AND l.status = 'ACTIVE'")
     int countLikesByBoardId(@Param("boardId") Long boardId);
 
-    @Query("SELECT b FROM Board b WHERE b.theme.id = :themeId ORDER BY b.createdDate DESC")
-    Page<Board> findByThemeIdOrderByDate(@Param("themeId") Long themeId, Pageable pageable);
+    @Query("SELECT b FROM Board b WHERE b.theme.id = :themeId AND b.isPublished = true  ORDER BY b.createdDate DESC")
+    Page<Board> findByThemeIdAndIsPublishedTrueOrderByDate(@Param("themeId") Long themeId, Pageable pageable);
 
-    @Query("SELECT b FROM Board b WHERE b.theme.id = :themeId ORDER BY (SELECT COUNT(bl) FROM BoardLike bl " +
+    @Query("SELECT b FROM Board b WHERE b.theme.id = :themeId AND b.isPublished = true ORDER BY (SELECT COUNT(bl) FROM BoardLike bl " +
             "WHERE bl.board.id = b.id AND bl.status = 'ACTIVE') DESC")
-    Page<Board> findByThemeIdOrderByLikeCount(@Param("themeId") Long themeId, Pageable pageable);
+    Page<Board> findByThemeIdAndIsPublishedTrueOrderByLikeCount(@Param("themeId") Long themeId, Pageable pageable);
 
     @Query("SELECT COUNT(b) FROM Board b WHERE b.theme = :theme AND b.isPublished = :isPublished")
     int countByThemeAndIsPublished(Theme theme, boolean isPublished);

--- a/src/main/java/depth/mvp/ns/domain/board/dto/response/SaveBoardRes.java
+++ b/src/main/java/depth/mvp/ns/domain/board/dto/response/SaveBoardRes.java
@@ -1,0 +1,17 @@
+package depth.mvp.ns.domain.board.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SaveBoardRes {
+    private String message; // 성공 메세지
+    private Long boardId; // 임시저장된 글ID
+
+    @Builder
+    public SaveBoardRes(String message, Long boardId){
+        this.message = message;
+        this.boardId = boardId;
+    }
+
+}

--- a/src/main/java/depth/mvp/ns/domain/board/service/BoardService.java
+++ b/src/main/java/depth/mvp/ns/domain/board/service/BoardService.java
@@ -5,6 +5,7 @@ import depth.mvp.ns.domain.board.domain.repository.BoardRepository;
 import depth.mvp.ns.domain.board.dto.request.PublishReq;
 import depth.mvp.ns.domain.board.dto.request.SaveDraftReq;
 import depth.mvp.ns.domain.board.dto.request.UpdateReq;
+import depth.mvp.ns.domain.board.dto.response.SaveBoardRes;
 import depth.mvp.ns.domain.board.dto.response.BoardLikeRes;
 import depth.mvp.ns.domain.board_like.domain.BoardLike;
 import depth.mvp.ns.domain.board_like.domain.repository.BoardLikeRepository;
@@ -61,9 +62,14 @@ public class BoardService {
 
         boardRepository.save(board);
 
+        SaveBoardRes saveBoardRes = SaveBoardRes.builder()
+                .message("임시 저장이 완료되었습니다.")
+                .boardId(board.getId())
+                .build();
+
         ApiResponse apiResponse = ApiResponse.builder()
                 .check(true)
-                .information("임시 저장이 완료되었습니다.")
+                .information(saveBoardRes)
                 .build();
 
         return ResponseEntity.ok(apiResponse);

--- a/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
+++ b/src/main/java/depth/mvp/ns/domain/theme/service/ThemeService.java
@@ -168,10 +168,10 @@ public class ThemeService {
 
         switch (sortBy) {
             case "likeCount":
-                boardPage = boardRepository.findByThemeIdOrderByLikeCount(themeId, pageable);
+                boardPage = boardRepository.findByThemeIdAndIsPublishedTrueOrderByLikeCount(themeId, pageable);
                 break;
             case "date":
-                boardPage = boardRepository.findByThemeIdOrderByDate(themeId, pageable);
+                boardPage = boardRepository.findByThemeIdAndIsPublishedTrueOrderByDate(themeId, pageable);
                 break;
             default:
                 Errors errors = new BindException(sortBy, "sortBy");


### PR DESCRIPTION
## 📝작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요
- 임시저장 api응답에 boardId값 추가하였습니다. (저장 완료 메세지도 반환 할 수 있는 DTO클래스를 생성했습니다.)
- 주제 상세 조회시 발행된 게시글만 조회할 수 있는 조건을 추가했습니다.

## 💬리뷰 요구사항(선택)
> 리뷰어가 신경써서 봐주었으면 하는 부분이 있다면 작성해주세요
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
-


## ✅Check
- [ ] 각 기능에 대한 테스트
- [ ] label
- [ ] API 명세서 작성


## #️⃣연관된 이슈
> ex) #이슈번호
-


## 💡References(선택)
> 작업하면서 참고한 레퍼런스가 있다면 첨부해주세요
- 
